### PR TITLE
Fix authentication for proxied websocket connection

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -1,6 +1,6 @@
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {
+let socket = new Socket("ws://localhost:4100/socket", {
   params: {token: window.userToken},
   logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
 })

--- a/lib/rumbl_proxy/ws_reverse_proxy/aaa.ex
+++ b/lib/rumbl_proxy/ws_reverse_proxy/aaa.ex
@@ -8,24 +8,9 @@ defmodule RumblProxy.WSReverseProxy.AAA do
   # alias RumblProxy.Config
 
   @impl RumblProxy.WSReverseProxy.CallbackModule
-  def websocket_endpoint(_req, _opts) do
+  def websocket_endpoint(req, _opts) do
     "http://localhost:4000"
     |> sub_scheme()
-    |> URI.merge("/socket/websocket")
-
-    # "http://192.168.1.64:8080"
-    # |> sub_scheme()
-    # |> URI.merge("/guacamole/websocket-tunnel")
-  end
-
-  @impl RumblProxy.WSReverseProxy.CallbackModule
-  def conn_options(req, _opts) do
-    case :cowboy_req.header("cookie", req) do
-      :undefined ->
-        []
-
-      cookie ->
-        [extra_headers: [{"cookie", cookie}]]
-    end
+    |> URI.merge(%URI{path: "/socket/websocket", query: req.qs})
   end
 end


### PR DESCRIPTION
Проблема была в аутентификации проксируемого websocket-соединения, поэтому в логах ты видел сообщения типа

```
[info] REFUSED CONNECTION TO RumblWeb.UserSocket in 161µs
  Transport: :websocket
  Serializer: Phoenix.Socket.V1.JSONSerializer
  Connect Info: %{}
  Parameters: %{}
[debug] websocket 
```

Для своего приложения я проксировал websocket-соединения на Rails-сервер, там аутентификация осуществлялась через куки (поэтому я реализовал необязательный колбэк `conn_options/2`, в котором пробрасывал куки). 

У тебя же аутентификация сокета осуществляется через query-параметр `token`:

https://github.com/focused/rumbl/blob/596d6391547dbac8ead9a2d50e82fb3fbe40f0bb/lib/rumbl_web/channels/user_socket.ex#L21-L34

Так как прокси не пробрасывает query-параметры, то `UserSocket` отказывает в соединении. 

Решение: передавать query-параметры изначального запроса (поле `:qs` структуры `cowboy_req:req`) при проксировании. Это можно сделать, изменив колбэк `websocket_endpoint/2`.